### PR TITLE
added attr_accessor for :text so spec passes on copied/pasted code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ We're not going to go deeply into creating models in this lesson, as you've cove
 ```ruby
 
 class TextAnalyzer
+  attr_accessor :text
 
   def initialize(text)
     @text = text


### PR DESCRIPTION
A `TextAnalyzer` spec `can have text` fails because of missing `attr_accessor`. As this was code copied/pasted, I thought it shouldn't be responsibility of student to catch the mistake and correct it.