### PR TITLE
Add expectation to avoid false positives on errors

### DIFF
--- a/spec/integrating_models_sinatra_walkthrough_spec.rb
+++ b/spec/integrating_models_sinatra_walkthrough_spec.rb
@@ -19,6 +19,7 @@ describe App do
 
       fill_in(:user_text, :with => "Green Eggs and Ham")
       click_button "submit"
+      expect(page.status_code).to eq(200)
       expect(page).to have_text("Number of Words: 4")
       expect(page).to have_text("Vowels: 5")
       expect(page).to have_text("Consonants: 10")


### PR DESCRIPTION
This was passing right away even when the student wasn't passing instance variables properly from controller to view, because somehow this content ended up on the error page. Adding a status code check makes sure that there isn't a server error here.